### PR TITLE
bail on missing key

### DIFF
--- a/lib/ShardedKV/Storage/Rest.pm
+++ b/lib/ShardedKV/Storage/Rest.pm
@@ -71,6 +71,8 @@ sub _send_http_request {
 sub get {
     my ($self, $key) = @_;
 
+    return unless defined $key;
+
     my $response = $self->_send_http_request('GET', $key);
     my $code = $response->{status};
     return unless defined $code;
@@ -85,6 +87,7 @@ sub get {
 sub set {
     my ($self, $key, $value_ref) = @_;
 
+    return unless defined $key;
     return unless $value_ref;
 
     my $response = $self->_send_http_request('PUT', $key, $value_ref);
@@ -99,6 +102,8 @@ sub set {
 
 sub delete {
     my ($self, $key) = @_;
+
+    return unless defined $key;
 
     my $response = $self->_send_http_request('DELETE', $key);
     my $code = $response->{status};


### PR DESCRIPTION
```
perl> $stores[0]->delete()

Use of uninitialized value in subroutine entry at /usr/local/booking-perl/5.18.2/site/lib/ShardedKV/Continuum/Jump.pm line 23.

Use of uninitialized value $key in concatenation (.) or string at /usr/local/booking-perl/5.18.2/site/lib/ShardedKV/Storage/Rest.pm line 45.

Use of uninitialized value $key in concatenation (.) or string at /usr/local/booking-perl/5.18.2/site/lib/ShardedKV/Storage/Rest.pm line 45.

-> 0;
```

This actually issues a DELETE request for '/', which under certain configurations, may result in data loss.
