### PR TITLE
Handling 404s for DELETEs

### DIFF
--- a/lib/ShardedKV/Storage/Rest.pm
+++ b/lib/ShardedKV/Storage/Rest.pm
@@ -114,6 +114,9 @@ sub delete {
     if ($code >= 200 && $code < 300) {
         return 1;
     }
+    if ($code == 404) {
+        return 1; # already gone
+    }
     return 0;
 }
 

--- a/t/rest.t
+++ b/t/rest.t
@@ -131,6 +131,7 @@ is($skv->delete("${key}0"), 1);
 # Delete successes
 is($skv->delete("DELETE-200"), 1);
 is($skv->delete("DELETE-204"), 1);
+is($skv->delete("DELETE-404"), 1);
 
 # Delete failures
 is($skv->delete("DELETE-403"), 0);

--- a/t/rest.t
+++ b/t/rest.t
@@ -60,6 +60,9 @@ sub Test::HTTP::Server::Request::test
         }
     } elsif ($self->{request}->[0] eq 'DELETE') {
         $self->{out_headers}->{'Content-Length'} = 0;
+        if ($path =~ m@\A /test/DELETE-(\d{3}) \z@x) {
+            $self->{out_code} = "$1 ($1 Response)";
+        }
         unlink "$tempdir/$key.$me";
     }
     return "";
@@ -124,5 +127,13 @@ foreach my $i (0..$num_items) {
 # Multiple delete ok
 is($skv->delete("${key}0"), 1);
 is($skv->delete("${key}0"), 1);
+
+# Delete successes
+is($skv->delete("DELETE-200"), 1);
+is($skv->delete("DELETE-204"), 1);
+
+# Delete failures
+is($skv->delete("DELETE-403"), 0);
+is($skv->delete("DELETE-500"), 0);
 
 done_testing();

--- a/t/rest.t
+++ b/t/rest.t
@@ -121,5 +121,8 @@ foreach my $i (0..$num_items) {
     is($skv->get("${key}$i"), undef);
 }
 
+# Multiple delete ok
+is($skv->delete("${key}0"), 1);
+is($skv->delete("${key}0"), 1);
 
 done_testing();


### PR DESCRIPTION
It seems sane to me to accept HTTP 404 as success for delete()s as the result is what we want.

I toyed with returning "0E0" instead but decided it probably benefitted few people.

Cheers,
-Nate
